### PR TITLE
OSX Native Library Build Aids

### DIFF
--- a/jni/README_OSX.md
+++ b/jni/README_OSX.md
@@ -1,0 +1,36 @@
+# OSX Native Build Instructions
+
+## Dependencies
+
+### Gamepad JNI
+
+You shouldn't need anything special to build this.
+
+### NV AVC Decoder
+
+To build the NV AVC Decoder you'll need ffmpeg, which will bring along libavcodec and its friends.
+
+### NV Opus Decoder
+
+To build the NV Opus Decoder you'll need opus (libopus). 
+
+## Building Natively
+
+To automatically build the 3 native libraries, run 
+
+    build_osx.sh
+
+from the `jni` directory.
+
+This will build the osx versions each of the libraries, and then symlink them conveniently into the top level directory. 
+
+## Including the Binaries
+
+First, create a file called `platform` in `jni`, and make its first line `osx`.
+If you aren't sure how best to that, try `echo osx > platform`.
+
+Then, in your Java build environment (e.g. IDE), add the JVM flag:
+
+    -Djava.library.path=[limelight-pc]/jni
+
+

--- a/jni/README_OSX.md
+++ b/jni/README_OSX.md
@@ -22,15 +22,12 @@ To automatically build the 3 native libraries, run
 
 from the `jni` directory.
 
-This will build the osx versions each of the libraries, and then symlink them conveniently into the top level directory. 
+This will build the osx versions each of the libraries, and then copy them conveniently into the top level directory. 
 
 ## Including the Binaries
 
-First, create a file called `platform` in `jni`, and make its first line `osx`.
-If you aren't sure how best to that, try `echo osx > platform`.
+In your Java build environment (e.g. IDE), add the JVM flag:
 
-Then, in your Java build environment (e.g. IDE), add the JVM flag:
-
-    -Djava.library.path=[limelight-pc]/jni
+    -Djava.library.path=[limelight-pc]/libs/osx
 
 

--- a/jni/build_osx.sh
+++ b/jni/build_osx.sh
@@ -9,8 +9,8 @@ echo "Building NV AVC Decoder"
 echo "Building NV OPUS Decoder"
 (cd nv_opus_dec && sh buildosx.sh)
 
-echo "Linking to jni/"
+echo "Copying to libs/osx/"
 
-ln -s gamepad_jni/libgamepad_jni.dylib libgamepad_jni.dylib 
-ln -s nv_avc_dec/libnv_avc_dec.dylib libnv_avc_dec.dylib
-ln -s nv_opus_dec/libnv_opus_dec.dylib libnv_opus_dec.dylib 
+cp gamepad_jni/libgamepad_jni.dylib ../libs/osx/libgamepad_jni.dylib 
+cp nv_avc_dec/libnv_avc_dec.dylib ../libs/osx/libnv_avc_dec.dylib
+cp nv_opus_dec/libnv_opus_dec.dylib ../libs/osx/libnv_opus_dec.dylib 

--- a/jni/build_osx.sh
+++ b/jni/build_osx.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Building Gamepad JNI"
+(cd gamepad_jni && sh buildosx.sh)
+
+echo "Building NV AVC Decoder"
+(cd nv_avc_dec && sh buildosx.sh)
+
+echo "Building NV OPUS Decoder"
+(cd nv_opus_dec && sh buildosx.sh)
+
+echo "Linking to jni/"
+
+ln -s gamepad_jni/libgamepad_jni.dylib libgamepad_jni.dylib 
+ln -s nv_avc_dec/libnv_avc_dec.dylib libnv_avc_dec.dylib
+ln -s nv_opus_dec/libnv_opus_dec.dylib libnv_opus_dec.dylib 

--- a/jni/gamepad_jni/buildosx.sh
+++ b/jni/gamepad_jni/buildosx.sh
@@ -1,5 +1,5 @@
 rm *.o libgamepad_jni.dylib
-gcc -I /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include/ -I /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include/darwin -fPIC -c *.c
+gcc -I ${JAVA_HOME}/include/ -I ${JAVA_HOME}/include/darwin -fPIC -c *.c
 gcc -shared -o libgamepad_jni.dylib *.o -L./osx -lstem_gamepad -lpthread -framework IOKit -framework CoreFoundation
 rm *.o
 

--- a/jni/nv_avc_dec/buildosx.sh
+++ b/jni/nv_avc_dec/buildosx.sh
@@ -1,0 +1,5 @@
+rm *.o libnv_avc_dec.dylib
+gcc -I ${JAVA_HOME}/include/ -I ./inc -fPIC -L. -c *.c
+gcc -shared -Wl,-install_name,libnv_avc_dec.dylib -Wl,-undefined,dynamic_lookup -o libnv_avc_dec.dylib *.o -L. -lavcodec -lavfilter -lavformat -lavutil -lswresample -lswscale
+rm *.o
+

--- a/jni/nv_opus_dec/buildosx.sh
+++ b/jni/nv_opus_dec/buildosx.sh
@@ -1,0 +1,5 @@
+rm *.o libnv_opus_dec.dylib
+gcc -I include -I ${JAVA_HOME}/include/ -I ./inc -fPIC -c *.c
+gcc -shared -Wl,-install_name,libnv_opus_dec.dylib -Wl,-undefined,dynamic_lookup -o libnv_opus_dec.dylib *.o -L. -lopus
+rm *.o
+


### PR DESCRIPTION
This PR contains documentation and tooling supporting building the native library dependencies included with limelight on OSX, including:

* A readme for how to build the JNIs (including external deps) on OSX and include them in from-source running/debugging
* Build scripts to correctly compile the nv_avc_dec and nv_opus_dec on OSX (appropriate linker flags)
* An improvement to the OSX build script for the gamepad_jni, utilizing the `JAVA_HOME` property instead of hardcoded jdk versions (7u45). This fix should be propagated to other platforms. 

With this pull request, one can easily pull the project into an IDE and run the entire thing from Limelight.java on OSX. 