### PR TITLE
Fix stream window tap key input bug, issue #80

### DIFF
--- a/src/com/limelight/gui/StreamFrame.java
+++ b/src/com/limelight/gui/StreamFrame.java
@@ -84,6 +84,7 @@ public class StreamFrame extends JFrame {
 		renderingSurface.setFocusable(true);
 		renderingSurface.setLayout(new BoxLayout(renderingSurface, BoxLayout.Y_AXIS));
 		renderingSurface.setVisible(true);
+		renderingSurface.setFocusTraversalKeysEnabled(false);
 		
 		contentPane.setLayout(new BorderLayout());
 		contentPane.add(renderingSurface, "Center");


### PR DESCRIPTION
Disabled renderingSurface's focuse traversal key which blocks Tab key input event.